### PR TITLE
Trying to keep linux from loading the windows gemspec files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,7 @@ namespace :all do
 end
 
 namespace :windows do
-  spec_path = File.join(File.dirname(__FILE__), "rest-client-windows-mingw-ucrt.gemspec")
+  spec_path = File.join(File.dirname(__FILE__), "rest-client-universal-mingw-ucrt.gemspec")
 
   WINDOWS_PLATFORMS.each do |platform|
     namespace platform do

--- a/rest-client-universal-mingw-ucrt.gemspec
+++ b/rest-client-universal-mingw-ucrt.gemspec
@@ -13,19 +13,7 @@ spec = Gem::Specification.load(main_gemspec_path)
 spec.license = "MIT"
 
 # Get the platform from environment or default to current Ruby platform
-platform = ENV["BUILD_PLATFORM"] || RUBY_PLATFORM
+spec.platform = Gem::Platform.new(%w{universal mingw-ucrt})
 
-# Only modify the spec for Windows platforms
-case platform
-when /(mingw-ucrt|mingw32|mswin32)/
-  # Set the platform for Windows builds
-  spec.platform = platform
-
-  # Ensure FFI dependency is present for Windows platforms
-  # (This might already be handled in the main gemspec, but we ensure it here)
-  unless spec.dependencies.any? { |dep| dep.name == "ffi" }
-    spec.add_dependency("ffi", ">= 1.15.5", "< 1.18.0")
-  end
-end
-
+spec.add_dependency("ffi", ">= 1.15.5", "< 1.18.0")
 spec

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -40,9 +40,6 @@ spec = Gem::Specification.new do |s|
   s.add_dependency("mime-types", ">= 1.16", "< 4.0")
   s.add_dependency("netrc", "~> 0.8")
 
-  # Add FFI dependency for Windows platforms
-  s.add_dependency("ffi", ">= 1.15.5", "< 1.18.0") if Gem.win_platform?
-
   s.required_ruby_version = ">= 3.1.0"
 end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Linux nodes in the verify pipeline keep trying to load (and fail at loading) the Windows gemspec. Here we tweak the gemspec to look more like chef

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
