### PR TITLE
pin fiddle for windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,12 @@ source "https://rubygems.org"
 
 gemspec name: "rest-client"
 
+if RUBY_PLATFORM =~ /mingw|mswin/
+  gem "fiddle", "= 1.1.0"
+else
+  gem "fiddle", "~> 1.1.8"
+end
+
 group :test do
   gem "rake"
 end

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -34,7 +34,6 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency("webmock", "~> 2.0")
 
   s.add_dependency("base64")
-  s.add_dependency("fiddle")
   s.add_dependency("http-accept", "~> 2.1.0")
   s.add_dependency("http-cookie", ">= 1.0.2", "< 2.0")
   s.add_dependency("mime-types", ">= 1.16", "< 4.0")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
pinning fiddle to 1.1.0 for windows and to 1.1.8 otherwise because windows complains that 1.1.0 is already activated.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
